### PR TITLE
Add implementation with test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,8 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.6.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.6.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
+    testImplementation 'com.approvaltests:approvaltests:24.21.0'
 }
 
 group = 'com.gildedrose'

--- a/src/main/java/com/gildedrose/GildedRose.java
+++ b/src/main/java/com/gildedrose/GildedRose.java
@@ -1,5 +1,13 @@
 package com.gildedrose;
 
+import com.gildedrose.strategy.UpdateStrategy;
+import com.gildedrose.strategy.StrategyFactory;
+
+/**
+ * Main class for updating the inventory of the Gilded Rose inn.
+ * <p>
+ * Delegates item update logic to specific strategies based on item type.
+ */
 class GildedRose {
     Item[] items;
 
@@ -7,56 +15,13 @@ class GildedRose {
         this.items = items;
     }
 
+    /**
+     * Updates the quality and sellIn values for all items in inventory.
+     */
     public void updateQuality() {
-        for (int i = 0; i < items.length; i++) {
-            if (!items[i].name.equals("Aged Brie")
-                    && !items[i].name.equals("Backstage passes to a TAFKAL80ETC concert")) {
-                if (items[i].quality > 0) {
-                    if (!items[i].name.equals("Sulfuras, Hand of Ragnaros")) {
-                        items[i].quality = items[i].quality - 1;
-                    }
-                }
-            } else {
-                if (items[i].quality < 50) {
-                    items[i].quality = items[i].quality + 1;
-
-                    if (items[i].name.equals("Backstage passes to a TAFKAL80ETC concert")) {
-                        if (items[i].sellIn < 11) {
-                            if (items[i].quality < 50) {
-                                items[i].quality = items[i].quality + 1;
-                            }
-                        }
-
-                        if (items[i].sellIn < 6) {
-                            if (items[i].quality < 50) {
-                                items[i].quality = items[i].quality + 1;
-                            }
-                        }
-                    }
-                }
-            }
-
-            if (!items[i].name.equals("Sulfuras, Hand of Ragnaros")) {
-                items[i].sellIn = items[i].sellIn - 1;
-            }
-
-            if (items[i].sellIn < 0) {
-                if (!items[i].name.equals("Aged Brie")) {
-                    if (!items[i].name.equals("Backstage passes to a TAFKAL80ETC concert")) {
-                        if (items[i].quality > 0) {
-                            if (!items[i].name.equals("Sulfuras, Hand of Ragnaros")) {
-                                items[i].quality = items[i].quality - 1;
-                            }
-                        }
-                    } else {
-                        items[i].quality = items[i].quality - items[i].quality;
-                    }
-                } else {
-                    if (items[i].quality < 50) {
-                        items[i].quality = items[i].quality + 1;
-                    }
-                }
-            }
+        for (Item item : items) {
+            UpdateStrategy strategy = StrategyFactory.getStrategy(item);
+            strategy.update(item);
         }
     }
 }

--- a/src/main/java/com/gildedrose/Item.java
+++ b/src/main/java/com/gildedrose/Item.java
@@ -1,5 +1,10 @@
 package com.gildedrose;
 
+/**
+ * Represents an item in the Gilded Rose inventory.
+ * <p>
+ * Note: This class should not be modified as per kata constraints.
+ */
 public class Item {
 
     public String name;

--- a/src/main/java/com/gildedrose/strategy/AgedBrieStrategy.java
+++ b/src/main/java/com/gildedrose/strategy/AgedBrieStrategy.java
@@ -1,0 +1,18 @@
+package com.gildedrose.strategy;
+
+import com.gildedrose.Item;
+
+/**
+ * Update strategy for "Aged Brie" items.
+ * <p>
+ * "Aged Brie" increases in quality as it ages, up to a maximum of 50.
+ */
+public class AgedBrieStrategy implements UpdateStrategy {
+    public void update(Item item) {
+        item.sellIn--;
+        if (item.quality < 50) {
+            item.quality += (item.sellIn < 0) ? 2 : 1;
+        }
+        item.quality = Math.min(50, item.quality);
+    }
+}

--- a/src/main/java/com/gildedrose/strategy/BackstagePassStrategy.java
+++ b/src/main/java/com/gildedrose/strategy/BackstagePassStrategy.java
@@ -1,0 +1,27 @@
+package com.gildedrose.strategy;
+
+import com.gildedrose.Item;
+
+/**
+ * Update strategy for "Backstage passes to a TAFKAL80ETC concert".
+ * <p>
+ * Quality increases as the concert approaches, with special rules:
+ * <ul>
+ *   <li>+1 when more than 10 days left</li>
+ *   <li>+2 when 6-10 days left</li>
+ *   <li>+3 when 0-5 days left</li>
+ *   <li>Quality drops to 0 after the concert</li>
+ * </ul>
+ */
+public class BackstagePassStrategy implements UpdateStrategy {
+    public void update(Item item) {
+        item.sellIn--;
+        if (item.sellIn < 0) {
+            item.quality = 0;
+        } else {
+            item.quality += (item.sellIn < 5) ? 3 :     
+                            (item.sellIn < 10) ? 2 : 1;
+        }
+        item.quality = Math.min(50, item.quality);
+    }
+}

--- a/src/main/java/com/gildedrose/strategy/ConjuredStrategy.java
+++ b/src/main/java/com/gildedrose/strategy/ConjuredStrategy.java
@@ -1,0 +1,17 @@
+package com.gildedrose.strategy;
+
+import com.gildedrose.Item;
+
+/**
+ * Update strategy for "Conjured" items.
+ * <p>
+ * "Conjured" items degrade in quality twice as fast as normal items.
+ */
+public class ConjuredStrategy implements UpdateStrategy {
+    public void update(Item item) {
+        item.sellIn--;
+        int baseDegradation = (item.sellIn < 0) ? 2 : 1;
+        int degradation = baseDegradation * 2;
+        item.quality = Math.max(0, item.quality - degradation);
+    }
+}

--- a/src/main/java/com/gildedrose/strategy/DefaultStrategy.java
+++ b/src/main/java/com/gildedrose/strategy/DefaultStrategy.java
@@ -1,0 +1,17 @@
+package com.gildedrose.strategy;
+
+import com.gildedrose.Item;
+
+/**
+ * Default update strategy for standard items.
+ * <p>
+ * Quality degrades by 1 before sell-in date, and by 2 after.
+ * Quality never drops below 0.
+ */
+public class DefaultStrategy implements UpdateStrategy {
+    public void update(Item item) {
+        item.sellIn--;
+        int degradation = (item.sellIn < 0) ? 2 : 1;
+        item.quality = Math.max(0, item.quality - degradation);
+    }
+}

--- a/src/main/java/com/gildedrose/strategy/StrategyFactory.java
+++ b/src/main/java/com/gildedrose/strategy/StrategyFactory.java
@@ -1,0 +1,23 @@
+package com.gildedrose.strategy;
+
+import java.util.Map;
+import java.util.HashMap;
+import com.gildedrose.Item;
+
+/**
+ * Factory for selecting the appropriate {@link UpdateStrategy} based on item name.
+ * <p>
+ * Ensures each item is updated according to its unique rules.
+ */
+public class StrategyFactory {
+    private static final Map<String, UpdateStrategy> STRATEGIES = Map.of(
+        "Aged Brie", new AgedBrieStrategy(),
+        "Backstage passes to a TAFKAL80ETC concert", new BackstagePassStrategy(),
+        "Sulfuras, Hand of Ragnaros", new SulfurasStrategy(),
+        "Conjured Mana Cake", new ConjuredStrategy()
+    );
+
+    public static UpdateStrategy getStrategy(Item item) {
+        return STRATEGIES.getOrDefault(item.name, new DefaultStrategy());
+    }
+}

--- a/src/main/java/com/gildedrose/strategy/SulfurasStrategy.java
+++ b/src/main/java/com/gildedrose/strategy/SulfurasStrategy.java
@@ -1,0 +1,14 @@
+package com.gildedrose.strategy;
+
+import com.gildedrose.Item;
+
+/**
+ * Update strategy for "Sulfuras, Hand of Ragnaros".
+ * <p>
+ * "Sulfuras" is a legendary item; its quality and sellIn never change.
+ */
+public class SulfurasStrategy implements UpdateStrategy {
+    public void update(Item item) {
+        // Legendary item - no changes
+    }
+}

--- a/src/main/java/com/gildedrose/strategy/UpdateStrategy.java
+++ b/src/main/java/com/gildedrose/strategy/UpdateStrategy.java
@@ -1,0 +1,17 @@
+package com.gildedrose.strategy;
+
+import com.gildedrose.Item;
+
+/**
+ * Defines the contract for updating the quality and sellIn values of an item.
+ * <p>
+ * Implementations encapsulate the specific update logic for different item types.
+ */
+public interface UpdateStrategy {
+    /**
+     * Updates the sellIn and quality of the given item according to specific rules.
+     *
+     * @param item the item to update
+     */
+    void update(Item item);
+}

--- a/src/test/java/com/gildedrose/GildedRoseTest.java
+++ b/src/test/java/com/gildedrose/GildedRoseTest.java
@@ -1,17 +1,155 @@
 package com.gildedrose;
 
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
+/**
+ * Integration tests for {@link GildedRose}.
+ * <p>
+ * Validates correct system behavior for all item types and edge cases.
+ */
 class GildedRoseTest {
 
     @Test
-    void foo() {
-        Item[] items = new Item[] { new Item("foo", 0, 0) };
+    void normalItem_degradesByOneBeforeSellIn() {
+        Item[] items = { new Item("Normal Item", 10, 20) };
         GildedRose app = new GildedRose(items);
+
         app.updateQuality();
-        assertEquals("fixme", app.items[0].name);
+
+        assertEquals(9, items[0].sellIn);
+        assertEquals(19, items[0].quality);
     }
 
+    @Test
+    void normalItem_degradesByTwoAfterSellIn() {
+        Item[] items = { new Item("Normal Item", 0, 20) };
+        GildedRose app = new GildedRose(items);
+
+        app.updateQuality();
+
+        assertEquals(-1, items[0].sellIn);
+        assertEquals(18, items[0].quality);
+    }
+
+    @Test
+    void normalItem_qualityNeverNegative() {
+        Item[] items = { new Item("Normal Item", 0, 0) };
+        GildedRose app = new GildedRose(items);
+
+        app.updateQuality();
+
+        assertEquals(-1, items[0].sellIn);
+        assertEquals(0, items[0].quality);
+    }
+
+    @Test
+    void agedBrie_increasesInQuality() {
+        Item[] items = { new Item("Aged Brie", 2, 0) };
+        GildedRose app = new GildedRose(items);
+
+        app.updateQuality();
+
+        assertEquals(1, items[0].sellIn);
+        assertEquals(1, items[0].quality);
+    }
+
+    @Test
+    void agedBrie_qualityNeverExceedsFifty() {
+        Item[] items = { new Item("Aged Brie", 2, 50) };
+        GildedRose app = new GildedRose(items);
+
+        app.updateQuality();
+
+        assertEquals(1, items[0].sellIn);
+        assertEquals(50, items[0].quality);
+    }
+
+    @Test
+    void sulfuras_neverChanges() {
+        Item[] items = { new Item("Sulfuras, Hand of Ragnaros", 0, 80) };
+        GildedRose app = new GildedRose(items);
+
+        app.updateQuality();
+
+        assertEquals(0, items[0].sellIn);
+        assertEquals(80, items[0].quality);
+    }
+
+    @Test
+    void backstagePass_increasesByOneWhenMoreThanTenDays() {
+        Item[] items = { new Item("Backstage passes to a TAFKAL80ETC concert", 15, 20) };
+        GildedRose app = new GildedRose(items);
+
+        app.updateQuality();
+
+        assertEquals(14, items[0].sellIn);
+        assertEquals(21, items[0].quality);
+    }
+
+    @Test
+    void backstagePass_increasesByTwoWhenTenOrLessDays() {
+        Item[] items = { new Item("Backstage passes to a TAFKAL80ETC concert", 10, 20) };
+        GildedRose app = new GildedRose(items);
+
+        app.updateQuality();
+
+        assertEquals(9, items[0].sellIn);
+        assertEquals(22, items[0].quality);
+    }
+
+    @Test
+    void backstagePass_increasesByThreeWhenFiveOrLessDays() {
+        Item[] items = { new Item("Backstage passes to a TAFKAL80ETC concert", 5, 20) };
+        GildedRose app = new GildedRose(items);
+
+        app.updateQuality();
+
+        assertEquals(4, items[0].sellIn);
+        assertEquals(23, items[0].quality);
+    }
+
+    @Test
+    void backstagePass_qualityDropsToZeroAfterConcert() {
+        Item[] items = { new Item("Backstage passes to a TAFKAL80ETC concert", 0, 20) };
+        GildedRose app = new GildedRose(items);
+
+        app.updateQuality();
+
+        assertEquals(-1, items[0].sellIn);
+        assertEquals(0, items[0].quality);
+    }
+
+    @Test
+    void conjuredItem_degradesTwiceAsFastBeforeSellIn() {
+        Item[] items = { new Item("Conjured Mana Cake", 3, 6) };
+        GildedRose app = new GildedRose(items);
+
+        app.updateQuality();
+
+        assertEquals(2, items[0].sellIn);
+        assertEquals(4, items[0].quality);
+    }
+
+    @Test
+    void conjuredItem_degradesFourTimesAsFastAfterSellIn() {
+        Item[] items = { new Item("Conjured Mana Cake", 0, 6) };
+        GildedRose app = new GildedRose(items);
+
+        app.updateQuality();
+
+        assertEquals(-1, items[0].sellIn);
+        assertEquals(2, items[0].quality);
+    }
+
+    @Test
+    void conjuredItem_qualityNeverNegative() {
+        Item[] items = { new Item("Conjured Mana Cake", 0, 3) };
+        GildedRose app = new GildedRose(items);
+
+        app.updateQuality();
+
+        assertEquals(-1, items[0].sellIn);
+        assertEquals(0, items[0].quality);
+    }
 }

--- a/src/test/java/com/gildedrose/strategy/AgedBrieStrategyTest.java
+++ b/src/test/java/com/gildedrose/strategy/AgedBrieStrategyTest.java
@@ -1,0 +1,46 @@
+package com.gildedrose.strategy;
+
+import com.gildedrose.Item;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link AgedBrieStrategy}.
+ * <p>
+ * Ensures "Aged Brie" items increase in quality over time and never exceed the maximum allowed quality.
+ */
+class AgedBrieStrategyTest {
+
+    @Test
+    void increasesQualityByOneBeforeSellIn() {
+        Item item = new Item("Aged Brie", 5, 10);
+        UpdateStrategy strategy = new AgedBrieStrategy();
+
+        strategy.update(item);
+
+        assertEquals(4, item.sellIn);
+        assertEquals(11, item.quality);
+    }
+
+    @Test
+    void increasesQualityByTwoAfterSellIn() {
+        Item item = new Item("Aged Brie", 0, 10);
+        UpdateStrategy strategy = new AgedBrieStrategy();
+
+        strategy.update(item);
+
+        assertEquals(-1, item.sellIn);
+        assertEquals(12, item.quality);
+    }
+
+    @Test
+    void qualityNeverExceedsFifty() {
+        Item item = new Item("Aged Brie", 5, 50);
+        UpdateStrategy strategy = new AgedBrieStrategy();
+
+        strategy.update(item);
+
+        assertEquals(4, item.sellIn);
+        assertEquals(50, item.quality);
+    }
+}

--- a/src/test/java/com/gildedrose/strategy/BackstagePassStrategyTest.java
+++ b/src/test/java/com/gildedrose/strategy/BackstagePassStrategyTest.java
@@ -1,0 +1,90 @@
+package com.gildedrose.strategy;
+
+import com.gildedrose.Item;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link BackstagePassStrategy}.
+ * <p>
+ * Verifies correct quality increases for backstage passes and quality drop after the concert.
+ */
+class BackstagePassStrategyTest {
+
+    @Test
+    void qualityIncreasesByOne_WhenMoreThanTenDaysLeft() {
+        Item item = new Item("Backstage passes to a TAFKAL80ETC concert", 15, 20);
+        UpdateStrategy strategy = new BackstagePassStrategy();
+
+        strategy.update(item);
+
+        assertEquals(14, item.sellIn, "SellIn should decrease by 1");
+        assertEquals(21, item.quality, "Quality should increase by 1 when >10 days left");
+    }
+
+    @Test
+    void qualityIncreasesByTwo_WhenBetweenSixAndTenDays() {
+        Item item = new Item("Backstage passes to a TAFKAL80ETC concert", 10, 20);
+        UpdateStrategy strategy = new BackstagePassStrategy();
+
+        strategy.update(item);
+
+        assertEquals(9, item.sellIn);
+        assertEquals(22, item.quality);
+    }
+
+    @Test
+    void qualityIncreasesByThree_WhenFiveDaysOrLess() {
+        Item item = new Item("Backstage passes to a TAFKAL80ETC concert", 5, 20);
+        UpdateStrategy strategy = new BackstagePassStrategy();
+
+        strategy.update(item);
+
+        assertEquals(4, item.sellIn);
+        assertEquals(23, item.quality);
+    }
+
+    @Test
+    void qualityDropsToZero_AfterConcert() {
+        Item item = new Item("Backstage passes to a TAFKAL80ETC concert", 0, 20);
+        UpdateStrategy strategy = new BackstagePassStrategy();
+
+        strategy.update(item);
+
+        assertEquals(-1, item.sellIn);
+        assertEquals(0, item.quality);
+    }
+
+    @Test
+    void qualityNeverExceedsFifty() {
+        Item item = new Item("Backstage passes to a TAFKAL80ETC concert", 5, 49);
+        UpdateStrategy strategy = new BackstagePassStrategy();
+
+        strategy.update(item);
+
+        assertEquals(4, item.sellIn);
+        assertEquals(50, item.quality);
+    }
+
+    @Test
+    void qualityCapsAtFifty_WhenNearLimit() {
+        Item item = new Item("Backstage passes to a TAFKAL80ETC concert", 3, 49);
+        UpdateStrategy strategy = new BackstagePassStrategy();
+
+        strategy.update(item);
+
+        assertEquals(2, item.sellIn);
+        assertEquals(50, item.quality);
+    }
+
+    @Test
+    void qualityHandlesEdgeCase_OneDayBeforeConcert() {
+        Item item = new Item("Backstage passes to a TAFKAL80ETC concert", 1, 20);
+        UpdateStrategy strategy = new BackstagePassStrategy();
+
+        strategy.update(item);
+
+        assertEquals(0, item.sellIn);
+        assertEquals(23, item.quality);
+    }
+}

--- a/src/test/java/com/gildedrose/strategy/ConjuredStrategy.java
+++ b/src/test/java/com/gildedrose/strategy/ConjuredStrategy.java
@@ -1,0 +1,57 @@
+package com.gildedrose.strategy;
+
+import com.gildedrose.Item;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link ConjuredStrategy}.
+ * <p>
+ * Validates that "Conjured" items degrade in quality twice as fast as normal items.
+ */
+class ConjuredStrategyTest {
+
+    @Test
+    void degradesQualityTwiceAsFastBeforeSellIn() {
+        Item item = new Item("Conjured Mana Cake", 3, 10);
+        UpdateStrategy strategy = new ConjuredStrategy();
+
+        strategy.update(item);
+
+        assertEquals(2, item.sellIn, "SellIn should decrease by 1");
+        assertEquals(8, item.quality, "Quality should decrease by 2 before sell-in");
+    }
+
+    @Test
+    void degradesQualityFourTimesAsFastAfterSellIn() {
+        Item item = new Item("Conjured Mana Cake", 0, 10);
+        UpdateStrategy strategy = new ConjuredStrategy();
+
+        strategy.update(item);
+
+        assertEquals(-1, item.sellIn, "SellIn should decrease by 1");
+        assertEquals(6, item.quality, "Quality should decrease by 4 after sell-in");
+    }
+
+    @Test
+    void qualityNeverNegative() {
+        Item item = new Item("Conjured Mana Cake", 0, 3);
+        UpdateStrategy strategy = new ConjuredStrategy();
+
+        strategy.update(item);
+
+        assertEquals(-1, item.sellIn);
+        assertEquals(0, item.quality, "Quality should not go below 0");
+    }
+
+    @Test
+    void qualityDegradesToZeroIfDegradationExceedsCurrentQuality() {
+        Item item = new Item("Conjured Mana Cake", 0, 2);
+        UpdateStrategy strategy = new ConjuredStrategy();
+
+        strategy.update(item);
+
+        assertEquals(-1, item.sellIn);
+        assertEquals(0, item.quality, "Quality should not go below 0");
+    }
+}

--- a/src/test/java/com/gildedrose/strategy/DefaultStrategy.java
+++ b/src/test/java/com/gildedrose/strategy/DefaultStrategy.java
@@ -1,0 +1,57 @@
+package com.gildedrose.strategy;
+
+import com.gildedrose.Item;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link DefaultStrategy}.
+ * <p>
+ * Ensures standard items degrade in quality appropriately and never go below zero.
+ */
+class DefaultStrategyTest {
+
+    @Test
+    void qualityDecreasesByOneBeforeSellIn() {
+        Item item = new Item("Normal Item", 10, 20);
+        UpdateStrategy strategy = new DefaultStrategy();
+
+        strategy.update(item);
+
+        assertEquals(9, item.sellIn, "SellIn should decrease by 1");
+        assertEquals(19, item.quality, "Quality should decrease by 1 before sell-in");
+    }
+
+    @Test
+    void qualityDecreasesByTwoAfterSellIn() {
+        Item item = new Item("Normal Item", 0, 20);
+        UpdateStrategy strategy = new DefaultStrategy();
+
+        strategy.update(item);
+
+        assertEquals(-1, item.sellIn, "SellIn should decrease by 1");
+        assertEquals(18, item.quality, "Quality should decrease by 2 after sell-in");
+    }
+
+    @Test
+    void qualityNeverGoesNegative() {
+        Item item = new Item("Normal Item", 0, 1);
+        UpdateStrategy strategy = new DefaultStrategy();
+
+        strategy.update(item);
+
+        assertEquals(-1, item.sellIn, "SellIn should decrease by 1");
+        assertEquals(0, item.quality, "Quality should not go below 0");
+    }
+
+    @Test
+    void qualityStaysAtZeroIfAlreadyZero() {
+        Item item = new Item("Normal Item", 5, 0);
+        UpdateStrategy strategy = new DefaultStrategy();
+
+        strategy.update(item);
+
+        assertEquals(4, item.sellIn, "SellIn should decrease by 1");
+        assertEquals(0, item.quality, "Quality should remain at 0");
+    }
+}

--- a/src/test/java/com/gildedrose/strategy/StrategyFactory.java
+++ b/src/test/java/com/gildedrose/strategy/StrategyFactory.java
@@ -1,0 +1,56 @@
+package com.gildedrose.strategy;
+
+import com.gildedrose.Item;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link StrategyFactory}.
+ * <p>
+ * Verifies correct mapping of item names to their respective update strategies.
+ */
+class StrategyFactoryTest {
+
+    @Test
+    void returnsAgedBrieStrategyForAgedBrie() {
+        Item item = new Item("Aged Brie", 10, 20);
+        UpdateStrategy strategy = StrategyFactory.getStrategy(item);
+        assertTrue(strategy instanceof AgedBrieStrategy, "Should return AgedBrieStrategy");
+    }
+
+    @Test
+    void returnsBackstagePassStrategyForBackstagePass() {
+        Item item = new Item("Backstage passes to a TAFKAL80ETC concert", 10, 20);
+        UpdateStrategy strategy = StrategyFactory.getStrategy(item);
+        assertTrue(strategy instanceof BackstagePassStrategy, "Should return BackstagePassStrategy");
+    }
+
+    @Test
+    void returnsSulfurasStrategyForSulfuras() {
+        Item item = new Item("Sulfuras, Hand of Ragnaros", 0, 80);
+        UpdateStrategy strategy = StrategyFactory.getStrategy(item);
+        assertTrue(strategy instanceof SulfurasStrategy, "Should return SulfurasStrategy");
+    }
+
+    @Test
+    void returnsConjuredStrategyForConjuredItem() {
+        Item item = new Item("Conjured Mana Cake", 3, 6);
+        UpdateStrategy strategy = StrategyFactory.getStrategy(item);
+        assertTrue(strategy instanceof ConjuredStrategy, "Should return ConjuredStrategy");
+    }
+
+    @Test
+    void returnsDefaultStrategyForNormalItem() {
+        Item item = new Item("Elixir of the Mongoose", 5, 7);
+        UpdateStrategy strategy = StrategyFactory.getStrategy(item);
+        assertTrue(strategy instanceof DefaultStrategy, "Should return DefaultStrategy for normal items");
+    }
+
+    @Test
+    void returnsDefaultStrategyForUnknownItem() {
+        Item item = new Item("Mystery Item", 5, 7);
+        UpdateStrategy strategy = StrategyFactory.getStrategy(item);
+        assertTrue(strategy instanceof DefaultStrategy, "Should return DefaultStrategy for unknown items");
+    }
+}

--- a/src/test/java/com/gildedrose/strategy/SulfurasStrategy.java
+++ b/src/test/java/com/gildedrose/strategy/SulfurasStrategy.java
@@ -1,0 +1,57 @@
+package com.gildedrose.strategy;
+
+import com.gildedrose.Item;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link SulfurasStrategy}.
+ * <p>
+ * Confirms that "Sulfuras" items never change in quality or sell-in value.
+ */
+class SulfurasStrategyTest {
+
+    @Test
+    void sulfurasQualityAndSellInRemainUnchanged_PositiveSellIn() {
+        Item item = new Item("Sulfuras, Hand of Ragnaros", 5, 80);
+        UpdateStrategy strategy = new SulfurasStrategy();
+
+        strategy.update(item);
+
+        assertEquals(5, item.sellIn, "SellIn should remain unchanged for Sulfuras");
+        assertEquals(80, item.quality, "Quality should remain unchanged for Sulfuras");
+    }
+
+    @Test
+    void sulfurasQualityAndSellInRemainUnchanged_ZeroSellIn() {
+        Item item = new Item("Sulfuras, Hand of Ragnaros", 0, 80);
+        UpdateStrategy strategy = new SulfurasStrategy();
+
+        strategy.update(item);
+
+        assertEquals(0, item.sellIn, "SellIn should remain unchanged for Sulfuras");
+        assertEquals(80, item.quality, "Quality should remain unchanged for Sulfuras");
+    }
+
+    @Test
+    void sulfurasQualityAndSellInRemainUnchanged_NegativeSellIn() {
+        Item item = new Item("Sulfuras, Hand of Ragnaros", -10, 80);
+        UpdateStrategy strategy = new SulfurasStrategy();
+
+        strategy.update(item);
+
+        assertEquals(-10, item.sellIn, "SellIn should remain unchanged for Sulfuras");
+        assertEquals(80, item.quality, "Quality should remain unchanged for Sulfuras");
+    }
+
+    @Test
+    void sulfurasQualityRemainsUnchanged_IfNot80() {
+        Item item = new Item("Sulfuras, Hand of Ragnaros", 2, 70);
+        UpdateStrategy strategy = new SulfurasStrategy();
+
+        strategy.update(item);
+
+        assertEquals(2, item.sellIn, "SellIn should remain unchanged for Sulfuras");
+        assertEquals(70, item.quality, "Quality should remain unchanged even if not 80");
+    }
+}


### PR DESCRIPTION
feat: implement strategy pattern for item updates
- Introduce UpdateStrategy interface and strategy classes for each item type.
- Refactor GildedRose to delegate update logic to strategies.

feat: add StrategyFactory for item type dispatch
- Implement StrategyFactory to map item names to strategies.

test: add unit tests for strategies
- Add unit tests for AgedBrieStrategy, BackstagePassStrategy, ConjuredStrategy, SulfurasStrategy, and DefaultStrategy.

test: add integration tests for GildedRose
- Add assertion-based integration tests for GildedRose covering all item types and edge cases.

docs: add JavaDoc to all classes and test files
- Add JavaDoc comments to production and test classes for maintainability.